### PR TITLE
Implements Course and Section time statistics

### DIFF
--- a/css/ztm-section-times.css
+++ b/css/ztm-section-times.css
@@ -1,0 +1,57 @@
+/*
+ * Author: Matt Smith
+ * GitHub: https://github.com/mattcsmith
+ * Date: 4th Jan 2024
+ * Description: Adds lecture time statistics to each section and the sidebar
+ */
+
+ /* NOTE: This includes more !important's than I'd like to have used               */
+ /*       However it couldn't really be avoided without making substaintial edits  */
+ /*       to the darkmode theme.                                                   */
+
+.sect-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.sect-watchtime {
+    display: flex;
+}
+
+.badge {
+  display: flex!important;
+  border: 1px solid rgb(245, 23, 103) !important;
+  border-radius: 20px!important;
+  padding: 0!important; 
+  margin-left: 15px!important;
+}
+
+ .badge .badge-prefix {
+  padding: 8px 6px 8px 12px;
+  background-color: rgba(245, 23, 103, 0.8) !important;
+  border-radius: 20px 0 0 20px;
+}
+
+.badge .badge-text {
+  padding: 8px 13px!important; 
+  background: unset!important;
+}
+
+.sidebar-times .badge {
+  width: 70%;
+  margin-bottom: 15px;
+}
+
+.sidebar-times .badge-prefix {
+  width: 50%;
+  text-align: left;
+}
+
+.sidebar-times {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 20px;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -5,52 +5,80 @@
 	"description": "Official extension for Zero To Mastery Academy students.",
 	"author": "Sithu Khant",
 	"homepage_url": "https://zerotomastery.io/",
-
-	"host_permissions": ["https://*.zerotomastery.io/*"],
+	"host_permissions": [
+		"https://*.zerotomastery.io/*"
+	],
 	"permissions": [
 		"storage",
 		"activeTab"
 	],
-
 	"action": {
-    	"default_title": "Zero To Mastery",
-    	"default_popup": "popup/popup.html",
-    	"default_icons": {
+		"default_title": "Zero To Mastery",
+		"default_popup": "popup/popup.html",
+		"default_icons": {
 			"16": "icons/icon16.png",
 			"32": "icons/icon32.png",
 			"48": "icons/icon48.png",
 			"128": "icons/icon128.png"
-	    }
-    },
-
+		}
+	},
 	"content_scripts": [
 		{
-			"js": ["scripts/ztm-homepage.js"],
-			"css": ["css/ztm-homepage.css"],
-			"matches": ["https://academy.zerotomastery.io/*"]
+			"js": [
+				"scripts/ztm-homepage.js"
+			],
+			"css": [
+				"css/ztm-homepage.css"
+			],
+			"matches": [
+				"https://academy.zerotomastery.io/*"
+			]
 		},
 		{
-			"js": ["scripts/ztm-lectures.js"],
-			"css": ["css/ztm-lectures.css"],
-			"matches": ["https://academy.zerotomastery.io/courses/*"]
+			"js": [
+				"scripts/ztm-lectures.js"
+			],
+			"css": [
+				"css/ztm-lectures.css"
+			],
+			"matches": [
+				"https://academy.zerotomastery.io/courses/*"
+			]
 		},
 		{
-			"js": ["scripts/ztm-darkmode.js"],
-			"matches": ["https://academy.zerotomastery.io/*"]
-		}
-	],
-
-	"web_accessible_resources" : [
+			"js": [
+				"scripts/ztm-section-times.js"
+			],
+			"css": [
+				"css/ztm-section-times.css"
+			],
+			"matches": [
+				"https://academy.zerotomastery.io/courses/enrolled/*"
+			]
+		},
 		{
-			"resources": ["css/ztm-darkmode.css"],
-			"matches": ["https://academy.zerotomastery.io/*"]
+			"js": [
+				"scripts/ztm-darkmode.js"
+			],
+			"matches": [
+				"https://academy.zerotomastery.io/*"
+			]
 		}
 	],
-	
-    "icons": {
+	"web_accessible_resources": [
+		{
+			"resources": [
+				"css/ztm-darkmode.css"
+			],
+			"matches": [
+				"https://academy.zerotomastery.io/*"
+			]
+		}
+	],
+	"icons": {
 		"16": "icons/icon16.png",
 		"32": "icons/icon32.png",
 		"48": "icons/icon48.png",
 		"128": "icons/icon128.png"
-    }
+	}
 }

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -30,6 +30,20 @@
 				</div>
 			</div>
 
+			<!-- Section Times -->
+			<div class="feature">
+				<div class="feature-title">
+					<p>Section Times</p>
+				</div>
+			
+				<div class="toggle-switch">
+					<label class="switch">
+						<input id='ztmSectionTimesCheckbox' type="checkbox">
+						<span class="slider round"></span>
+					</label>
+				</div>
+			</div>
+			
 			<!-- Keep resolution the same -->
 			<!-- <div class="feature">
 				<div class="feature-title">
@@ -60,5 +74,6 @@
 	</div>
 
 	<script type="text/javascript" src='popup.js'></script>
+	<script type="text/javascript" src='ztmSectionTime.js'></script>
 </body>
 </html>

--- a/popup/ztmSectionTime.js
+++ b/popup/ztmSectionTime.js
@@ -1,0 +1,41 @@
+/*
+ * Author: Matt Smith
+ * GitHub: https://github.com/mattcsmith
+ * Date: 4th Jan 2024
+ * Description: Adds lecture time statistics to each section and the sidebar
+ */
+
+// NOTE: I decided to abstract/seperate this from the popup.js file to seperate concerns.
+//       As the feature list grows, having all the code in popup.js will become hard to manage.
+
+// Wait for the DOM content to be fully loaded before executing the code
+document.addEventListener("DOMContentLoaded", async () => {
+  // Get the checkbox element from the DOM
+  const sectionTimesCheckbox = document.getElementById(
+    "ztmSectionTimesCheckbox"
+  );
+
+  // Retrieve the stored checkbox state from Chrome storage
+  const data = await chrome.storage.sync.get(
+    "ztmSectionTimesCheckboxIsChecked"
+  );
+
+  // Set the checkbox state based on the retrieved data (or default to false)
+  sectionTimesCheckbox.checked = data.ztmSectionTimesCheckboxIsChecked || false;
+
+  // Add an event listener for changes in the checkbox state
+  sectionTimesCheckbox.addEventListener("change", async () => {
+    // Update the checkbox state in Chrome storage
+    await chrome.storage.sync.set({
+      ztmSectionTimesCheckboxIsChecked: sectionTimesCheckbox.checked,
+    });
+
+    // Get information about the active tab
+    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+
+    // Send a message to the active tab with the updated checkbox state
+    await chrome?.tabs?.sendMessage(tabs[0].id, {
+      ztmSectionTimesCheckboxIsChecked: sectionTimesCheckbox.checked,
+    });
+  });
+});

--- a/scripts/ztm-section-times.js
+++ b/scripts/ztm-section-times.js
@@ -1,0 +1,159 @@
+/*
+ * Author: Matt Smith
+ * GitHub: https://github.com/mattcsmith
+ * Date: 4th Jan 2024
+ * Description: Adds lecture time statistics to each section and the sidebar
+ */
+
+// Helper function to format the lecture status
+const statusFormatter = (status) =>
+  status?.toLowerCase().includes("completed") ? "complete" : "incomplete";
+
+// Helper function to convert seconds to formatted time string
+const secondsToTime = (seconds) => {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const remainingSeconds = seconds % 60;
+  return hours > 0
+    ? `${hours}h ${minutes}m ${remainingSeconds}s`
+    : `${minutes}m ${remainingSeconds}s`;
+};
+
+// Function to update the section times and badges
+const updateSectionTimes = () => {
+  // Get all containers with the class .course-section
+  const containers = document.querySelectorAll(".course-section");
+
+  // Initialize an array to store all anchor information for each section
+  const allAnchorsArray = [];
+
+  // Object to store total times for each section and overall
+  const sectionTimes = { totalTime: 0, totalWatched: 0 };
+
+  // Loop through each container
+  containers.forEach((container) => {
+    // Get all anchor elements within the current container
+    const anchors = Array.from(container.querySelectorAll("a"));
+
+    // Loop through each anchor
+    anchors.forEach((a) => {
+      // Extract relevant information from the anchor
+      const lectureTitle = a.children[1].innerText;
+      const matchTime = lectureTitle.match(/\((\d{1,2}\s*:\s*\d{1,2}\s*)\)/);
+      const rawTime = matchTime ? matchTime[1].replaceAll(" ", "") : "0:0";
+      const timeInSecs = rawTime
+        .split(":")
+        .reduce((acc, time) => acc * 60 + parseInt(time, 10), 0);
+
+      // Extract section title and lecture status
+      const sectionTitle = container.children[0].innerText;
+      const lectureStatus = statusFormatter(a.children[0].ariaLabel);
+
+      // Store anchor information in the array
+      allAnchorsArray.push({
+        section: sectionTitle,
+        status: lectureStatus,
+        title: lectureTitle,
+        rawTime: rawTime,
+        timeInSecs: timeInSecs,
+        element: container,
+      });
+
+      // Update section times object
+      if (!sectionTimes[sectionTitle]) {
+        sectionTimes[sectionTitle] = { total: 0, watched: 0 };
+      }
+      sectionTimes[sectionTitle].total += timeInSecs;
+      if (lectureStatus === "complete")
+        sectionTimes[sectionTitle].watched += timeInSecs;
+
+      // Update overall times
+      sectionTimes.totalTime += timeInSecs;
+      if (lectureStatus === "complete") sectionTimes.totalWatched += timeInSecs;
+    });
+  });
+
+  // Update HTML for each container based on the calculated times
+  Array.from(containers).forEach((cont) => {
+    const sectionTitle = cont.children[0].innerText;
+    const data = sectionTimes[sectionTitle];
+    const watchedTime = secondsToTime(data?.watched || 0);
+    const totalTime = secondsToTime(data?.total || 0);
+
+    cont.children[0].innerHTML = `
+      <div class="sect-container">
+        <div class="sect-title">${sectionTitle}</div>
+        <div class="sect-watchtime">
+          <div class="badge">
+            <span class="badge-prefix">Watched</span>
+            <span class="badge-text">${watchedTime}</span>
+          </div>
+          <div class="badge">
+            <span class="badge-prefix">Total</span>
+            <span class="badge-text">${totalTime}</span>
+          </div>
+        </div>
+      </div>`;
+  });
+
+  // Update sidebar with overall course times
+  const sidebar = document.querySelector(".course-progress");
+  const newDiv = document.createElement("div");
+  const watchedTime = secondsToTime(sectionTimes.totalWatched || 0);
+  const totalTime = secondsToTime(sectionTimes.totalTime || 0);
+  const left = secondsToTime(
+    sectionTimes.totalTime - sectionTimes.totalWatched
+  );
+
+  newDiv.innerHTML = `
+    <div class="sidebar-times">
+      <div class="badge">
+        <span class="badge-prefix">Course Length</span>
+        <span class="badge-text">${totalTime}</span>
+      </div>
+      <div class="badge">
+        <span class="badge-prefix">Total Watched</span>
+        <span class="badge-text">${watchedTime}</span>
+      </div>
+      <div class="badge">
+        <span class="badge-prefix">Total Left</span>
+        <span class="badge-text">${left}</span>
+      </div>
+    </div>`;
+  sidebar.insertAdjacentElement("afterend", newDiv);
+};
+
+// Function to enable/disable functionality based on Chrome storage
+const updateFunctionality = (isEnabled) => {
+  if (!isEnabled) {
+    // Remove existing elements related to functionality
+    const elementsToRemove = [
+      ...document.querySelectorAll(".sect-watchtime"),
+      ...document.querySelectorAll(".sidebar-times"),
+    ];
+
+    elementsToRemove.forEach((element) => {
+      element.parentNode.removeChild(element);
+    });
+    return;
+  }
+
+  // Call the function to update section times and badges
+  updateSectionTimes();
+};
+
+// Retrieve the toggle state from Chrome storage
+chrome.storage.sync.get("ztmSectionTimesCheckboxIsChecked", (data) => {
+  const isEnabled = data?.ztmSectionTimesCheckboxIsChecked || false;
+  // Call the updateFunctionality with the retrieved isEnabled state
+  updateFunctionality(isEnabled);
+});
+
+// Listen for changes in Chrome storage
+chrome.storage.onChanged.addListener((changes, namespace) => {
+  if (namespace === "sync" && "ztmSectionTimesCheckboxIsChecked" in changes) {
+    const value = changes.ztmSectionTimesCheckboxIsChecked.newValue || false;
+    // Update functionality based on the changed value
+    updateFunctionality(value);
+  }
+});


### PR DESCRIPTION
This PR Introduces:
- Time statistics on each category/section of the course curriculum
- Time statistics in the sidebar for the course overall
- Toggle switch to enable all the statistics. 

Please see the video and images below. 

A couple of points worth noting: 
1. For the toggle switch I created a new JavaScript file ` popup/ztmSectionTime.js ` and then referenced it within the popout.html file. I opted for this to separate concerns and to avoid creating a difficult to read/edit JavaScript file as the extension grows. 
2. My code editor automatically formatted certain files like the manifest.json file. I noticed a student had a similar issue in [this PR](https://github.com/sithu-khant/ztm-extension/pull/2) where the quotes were changed. It might be worth adding some prettier rules to the project to create a more unified environment and prevent changes like these. 
3. I opted not to display the stats in the side bar when the video player was present as it felt a little too much. But this can be achieved by updating the `match` in the manifest from "https://academy.zerotomastery.io/courses/enrolled/*" to "https://academy.zerotomastery.io/courses/*"

https://www.loom.com/share/2d958548fc324322a70b40cae3fa1950?sid=024a827a-77dd-4fec-bd4c-4d4430e4496c

![image](https://github.com/sithu-khant/ztm-extension/assets/6190356/53857d13-c9c2-4367-a31d-0580fb44140d)

![image](https://github.com/sithu-khant/ztm-extension/assets/6190356/1609b3bb-27e2-4681-9b4b-da62eab2cfab)


