### PR TITLE
Addresses bugs with the section times

### DIFF
--- a/css/ztm-section-times.css
+++ b/css/ztm-section-times.css
@@ -31,6 +31,10 @@
   color: #646d76 !important;
 }
 
+.sidebar-times .badge {
+  margin-left: 0!important;
+}
+
 .badge .badge-prefix {
   padding: 8px 6px 8px 12px;
   background-color: #e3e3e3 !important;

--- a/manifest.json
+++ b/manifest.json
@@ -53,8 +53,9 @@
 				"css/ztm-section-times.css"
 			],
 			"matches": [
-				"https://academy.zerotomastery.io/courses/enrolled/*"
-			]
+				"https://academy.zerotomastery.io/courses/*"
+			],
+			"run_at": "document_idle"
 		},
 		{
 			"js": [

--- a/popup/ztmSectionTime.js
+++ b/popup/ztmSectionTime.js
@@ -5,20 +5,15 @@
  * Description: Adds lecture time statistics to each section and the sidebar
  */
 
-// NOTE: I decided to abstract/seperate this from the popup.js file to seperate concerns.
-//       As the feature list grows, having all the code in popup.js will become hard to manage.
+// NOTE: I decided to abstract/separate this from the popup.js file to separate concerns.
+// As the feature list grows, having all the code in popup.js will become hard to manage.
 
-function querySendTabMessage( options ){
-  chrome.tabs.query(
-    { active: true, currentWindow: true},
-    function (tabs) {
-      chrome.tabs.sendMessage(
-          tabs[0].id,
-          options
-      )
-    });
+// Function to query and send a message to the active tab
+function querySendTabMessage(options) {
+  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+    chrome.tabs.sendMessage(tabs[0].id, options);
+  });
 }
-
 
 // Wait for the DOM content to be fully loaded before executing the code
 document.addEventListener("DOMContentLoaded", async () => {
@@ -35,14 +30,15 @@ document.addEventListener("DOMContentLoaded", async () => {
   // Set the checkbox state based on the retrieved data (or default to false)
   sectionTimesCheckbox.checked = data.ztmSectionTimesCheckboxIsChecked || false;
 
-  sectionTimesCheckbox.addEventListener('change', function () {
-    chrome.storage.sync.set({'ztmSectionTimesCheckboxIsChecked': sectionTimesCheckbox.checked}, 
-    function () {
-      // sends
-      querySendTabMessage({
-          ztmSectionTimesCheckboxIsChecked:
-          sectionTimesCheckbox.checked
-      });
-    });
+  sectionTimesCheckbox.addEventListener("change", function () {
+    chrome.storage.sync.set(
+      { ztmSectionTimesCheckboxIsChecked: sectionTimesCheckbox.checked },
+      function () {
+        // Send a message to the active tab with the updated checkbox state
+        querySendTabMessage({
+          ztmSectionTimesCheckboxIsChecked: sectionTimesCheckbox.checked,
+        });
+      }
+    );
   });
 });


### PR DESCRIPTION
This PR Addresses a couple of bugs. Namely: 

### Stats only show on page refresh and not on initial load. 
This bug existed because of the way Teachable use React Router to update the route from the `/courses` page to `/courses/enrolled/<course_id>` page rather than reload the page. Because I had configured the manifest match to only embed the content script on the enrolled pages, it needed a page refresh to embed correctly. 

To address the fix I updated the manifest to embed the content script on the course page too and then used `location.pathname` to ensure it only updated the dom on the correct pages. I did have to use a Mutation Observer and this might not be the most performant way to achieve this. The alternative was to use a background.js script which seemed to introduce more bugs than it solved. 

### Sidebar Stats incorrectly showing on the Instructor Bio Tab
This feature essentially scans the page looking for the time stamps in the curriculum section. When you switch to the bio page, the extension no longer has access to the curriculum details and then displayed incorrect times. For now I disabled it showing on the Instructor Bio page. 
Another solution would have been to store the data to local storage. I opted not to do this due to the added complexities and the potential edge case that would break the feature. 

### Stats showing in places that it shouldn't. 
There were a couple of locations the stats showed up when you navigated around. I fixed these by ensuring two things: 
- It only updates the DOM on pages with /courses/enrolled/ in the url
- It will only update the DOM if the new elements are not already on the page. 

