### PR TITLE
Added `Hide Lecture Title`. Disabled `Section Time` feature for a while

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 4,
+  "semi": false,
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ MIT License
 * Sun Jan 14, 2024
 	* (1.14.01) - Converted indentations to spaces.
 	* (1.14.02) - Added `ztmHideLectureTitle` file in popup.
+	* (1.14.03) - `ztmHideLectureTitle` feature working.
 * Sat Jan 13, 2024
 	* (1.13.01) - Fixed the dark mode function not working properly.
 	* (1.13.02) - Refactored the popup files.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ MIT License
 	* (1.16.02) - Made reindentation to `ztm-section-times` code. Added `.prettierrc` 
 	file.
 	* (1.16.03) - Improved the code efficiency.
+	* (1.16.04) - `ztm-section-times` is working but it delays when on and off.
 * Sun Jan 14, 2024
 	* (1.14.01) - Converted indentations to spaces.
 	* (1.14.02) - Added `ztmHideLectureTitle` file in popup.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ MIT License
 
 * Tue Jan 16, 2024
 	* (1.16.01) - Cleaned the `ztmHideLectureTitle` code.
-	* (1.16.02) - Made reindentation to `ztm-section-times` code. Added `.prettierrc` file.
+	* (1.16.02) - Made reindentation to `ztm-section-times` code. Added `.prettierrc` 
+	file.
+	* (1.16.03) - Improved the code efficiency.
 * Sun Jan 14, 2024
 	* (1.14.01) - Converted indentations to spaces.
 	* (1.14.02) - Added `ztmHideLectureTitle` file in popup.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ MIT License
 
 ## Logs
 
+* Tue Jan 16, 2024
+	* (1.16.01) - Cleaned the `ztmHideLectureTitle` code.
 * Sun Jan 14, 2024
 	* (1.14.01) - Converted indentations to spaces.
 	* (1.14.02) - Added `ztmHideLectureTitle` file in popup.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ MIT License
 
 * Tue Jan 16, 2024
 	* (1.16.01) - Cleaned the `ztmHideLectureTitle` code.
+	* (1.16.02) - Made reindentation to `ztm-section-times` code. Added `.prettierrc` file.
 * Sun Jan 14, 2024
 	* (1.14.01) - Converted indentations to spaces.
 	* (1.14.02) - Added `ztmHideLectureTitle` file in popup.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ MIT License
 
 ## Logs
 
+* Sun Jan 14, 2024
+	* (1.14.01) - Converted indentations to spaces
 * Sat Jan 13, 2024
 	* (1.13.01) - Fixed the dark mode function not working properly.
 	* (1.13.02) - Refactored the popup files.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ MIT License
 ## Logs
 
 * Sun Jan 14, 2024
-	* (1.14.01) - Converted indentations to spaces
+	* (1.14.01) - Converted indentations to spaces.
+	* (1.14.02) - Added `ztmHideLectureTitle` file in popup.
 * Sat Jan 13, 2024
 	* (1.13.01) - Fixed the dark mode function not working properly.
 	* (1.13.02) - Refactored the popup files.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ Official extension for [Zero To Mastery Academy](https://zerotomastery.io/) stud
 ## Feature requests
 *(plans to add - top to bottom)*
 
-* [x] Focus Video (WIP)
+* [x] Hide Lecture Title (Done)
 * [x] Showing total amount of time in each section by [MathCSmith](https://github.com/mattcsmith) (WIP)
-* [ ] To keep the favourite courses at top
+* [x] To keep the favourite courses at top (WIP)
+* [ ] Focus Video
 * [ ] Keep the lecture video resolution the same
 
 
@@ -102,6 +103,7 @@ MIT License
 	file.
 	* (1.16.03) - Improved the code efficiency.
 	* (1.16.04) - `ztm-section-times` is working but it delays when on and off.
+	* (1.16.05) - Disabled `ztm-section-times` feature.
 * Sun Jan 14, 2024
 	* (1.14.01) - Converted indentations to spaces.
 	* (1.14.02) - Added `ztmHideLectureTitle` file in popup.

--- a/css/ztm-section-times.css
+++ b/css/ztm-section-times.css
@@ -9,7 +9,7 @@
  /*       However it couldn't really be avoided without making substaintial edits  */
  /*       to the darkmode theme.                                                   */
 
-.sect-container {
+/*.sect-container {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -66,4 +66,4 @@
   justify-content: center;
   align-items: center;
   margin-bottom: 20px;
-}
+}*/

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "Zero To Mastery",
-	"version": "2024.1.12",
+	"version": "2024.1.14",
 	"description": "Official extension for Zero To Mastery Academy students.",
 	"author": "Sithu Khant",
 	"homepage_url": "https://zerotomastery.io/",
@@ -23,6 +23,14 @@
 		}
 	},
 	"content_scripts": [
+		{
+			"js": [
+				"scripts/ztm-darkmode.js"
+			],
+			"matches": [
+				"https://academy.zerotomastery.io/*"
+			]
+		},
 		{
 			"js": [
 				"scripts/ztm-homepage.js"
@@ -59,10 +67,10 @@
 		},
 		{
 			"js": [
-				"scripts/ztm-darkmode.js"
+				"scripts/ztm-hide-lecture-title.js"
 			],
 			"matches": [
-				"https://academy.zerotomastery.io/*"
+				"https://academy.zerotomastery.io/courses/*"
 			]
 		}
 	],

--- a/manifest.json
+++ b/manifest.json
@@ -62,8 +62,7 @@
 			],
 			"matches": [
 				"https://academy.zerotomastery.io/*"
-			],
-			"run_at": "document_idle"
+			]
 		},
 		{
 			"js": [

--- a/manifest.json
+++ b/manifest.json
@@ -55,17 +55,6 @@
 		},
 		{
 			"js": [
-				"scripts/ztm-section-times.js"
-			],
-			"css": [
-				"css/ztm-section-times.css"
-			],
-			"matches": [
-				"https://academy.zerotomastery.io/*"
-			]
-		},
-		{
-			"js": [
 				"scripts/ztm-hide-lecture-title.js"
 			],
 			"matches": [

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -31,7 +31,7 @@
             </div>
 
             <!-- Section Times -->
-            <div class="feature">
+            <!-- <div class="feature">
                 <div class="feature-title">
                     <p>Section Times</p>
                 </div>
@@ -42,7 +42,7 @@
                         <span class="slider round"></span>
                     </label>
                 </div>
-            </div>
+            </div> -->
 
             <!-- Hide Lecture Title -->
             <div class="feature">

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -1,93 +1,93 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>Zero To Mastery - Extension</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Zero To Mastery - Extension</title>
 
-	<link rel="stylesheet" type="text/css" href="popup.css">
+    <link rel="stylesheet" type="text/css" href="popup.css">
 </head>
 <body>
 
-	<div class="ztm-container">
-		<div class="ztm-title">
-			<h3>Zero To Mastery</h3>
-		</div>
+    <div class="ztm-container">
+        <div class="ztm-title">
+            <h3>Zero To Mastery</h3>
+        </div>
 
-		<div class="feature-list">
+        <div class="feature-list">
 
-			<!-- Dark Mode -->
-			<div class="feature">
-				<div class="feature-title">
-					<p>Dark Mode</p>
-				</div>
+            <!-- Dark Mode -->
+            <div class="feature">
+                <div class="feature-title">
+                    <p>Dark Mode</p>
+                </div>
 
-				<div class="toggle-switch">
-					<label class="switch">
-						<input id='ztmDarkModeCheckbox' type="checkbox">
-						<span class="slider round"></span>
-					</label>
-				</div>
-			</div>
+                <div class="toggle-switch">
+                    <label class="switch">
+                        <input id='ztmDarkModeCheckbox' type="checkbox">
+                        <span class="slider round"></span>
+                    </label>
+                </div>
+            </div>
 
-			<!-- Section Times -->
-			<div class="feature">
-				<div class="feature-title">
-					<p>Section Times</p>
-				</div>
-			
-				<div class="toggle-switch">
-					<label class="switch">
-						<input id='ztmSectionTimesCheckbox' type="checkbox">
-						<span class="slider round"></span>
-					</label>
-				</div>
-			</div>
+            <!-- Section Times -->
+            <div class="feature">
+                <div class="feature-title">
+                    <p>Section Times</p>
+                </div>
+            
+                <div class="toggle-switch">
+                    <label class="switch">
+                        <input id='ztmSectionTimesCheckbox' type="checkbox">
+                        <span class="slider round"></span>
+                    </label>
+                </div>
+            </div>
 
-			<!-- Hide Lecture Title -->
-			<!-- <div class="feature">
-				<div class="feature-title">
-					<p>Hide Lecture Title</p>
-				</div>
+            <!-- Hide Lecture Title -->
+            <div class="feature">
+                <div class="feature-title">
+                    <p>Hide Lecture Title</p>
+                </div>
 
-				<div class="toggle-switch">
-					<label class="switch">
-						<input id='ztmHideLectureTitleCheckbox' type="checkbox">
-						<span class="slider round"></span>
-					</label>
-				</div>
-			</div> -->
-			
-			<!-- Keep resolution the same -->
-			<!-- <div class="feature">
-				<div class="feature-title">
-					<p>Keep resolution</p>
-				</div>
+                <div class="toggle-switch">
+                    <label class="switch">
+                        <input id='ztmHideLectureTitleCheckbox' type="checkbox">
+                        <span class="slider round"></span>
+                    </label>
+                </div>
+            </div>
+            
+            <!-- Keep resolution the same -->
+            <!-- <div class="feature">
+                <div class="feature-title">
+                    <p>Keep resolution</p>
+                </div>
 
-				<div class="select-box">
-					<select id='ztmKeepResolution'>
-					    <option value="Auto">Auto</option>
-					    <option value="224p">224p</option>
-					    <option value="360p">360p</option>
-					    <option value="540p">540p</option>
-					    <option value="720p">720p</option>
-					    <option value="1080p">1080p</option>
-					</select>
-				</div>
-			</div> -->
+                <div class="select-box">
+                    <select id='ztmKeepResolution'>
+                        <option value="Auto">Auto</option>
+                        <option value="224p">224p</option>
+                        <option value="360p">360p</option>
+                        <option value="540p">540p</option>
+                        <option value="720p">720p</option>
+                        <option value="1080p">1080p</option>
+                    </select>
+                </div>
+            </div> -->
 
-		</div>
+        </div>
 
-		<div class="ztm-footer">
-			<p>Enable the feature you want.</p>
-			<p>Default is disabled to keep it light.</p>
-			<br>
-			<p>Found issue? <a href="https://github.com/sithu-khant/ztm-extension/issues" target="_blank">Please report</a></p>
-		</div>
+        <div class="ztm-footer">
+            <p>Enable the feature you want.</p>
+            <p>Default is disabled to keep it light.</p>
+            <br>
+            <p>Found issue? <a href="https://github.com/sithu-khant/ztm-extension/issues" target="_blank">Please report</a></p>
+        </div>
 
-	</div>
+    </div>
 
-	<script type="text/javascript" src='ztmDarkMode.js'></script>
-	<script type="text/javascript" src='ztmSectionTime.js'></script>
+    <script type="text/javascript" src='ztmDarkMode.js'></script>
+    <script type="text/javascript" src='ztmSectionTime.js'></script>
 </body>
 </html>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -89,5 +89,6 @@
 
     <script type="text/javascript" src='ztmDarkMode.js'></script>
     <script type="text/javascript" src='ztmSectionTime.js'></script>
+    <script type="text/javascript" src='ztmHideLectureTitle.js'></script>
 </body>
 </html>

--- a/popup/ztmDarkMode.js
+++ b/popup/ztmDarkMode.js
@@ -7,26 +7,26 @@
 
 // Send the checkbox status to the active tab and current window
 const sendCheckStatusMessage = (checkboxStatus) => {
-	// Get the active tab and current window
-	chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-		// Send the checkbox status 
-		chrome.tabs.sendMessage(tabs[0].id, checkboxStatus);
-	})
+    // Get the active tab and current window
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        // Send the checkbox status 
+        chrome.tabs.sendMessage(tabs[0].id, checkboxStatus);
+    })
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-	const ztmCheckbox = document.getElementById('ztmDarkModeCheckbox');
+    const ztmCheckbox = document.getElementById('ztmDarkModeCheckbox');
 
-	ztmCheckbox.addEventListener('change', () => {
-		// Get the checkbox status
-		const checkboxStatus = { 'ztmDarkModeCheckboxIsChecked' : ztmCheckbox.checked }
+    ztmCheckbox.addEventListener('change', () => {
+        // Get the checkbox status
+        const checkboxStatus = { 'ztmDarkModeCheckboxIsChecked' : ztmCheckbox.checked }
 
-		// Set the initial checkbox status
-		chrome.storage.sync.set(checkboxStatus, () => {
-			// Send the checkbox status dynamically (callback function)
-			sendCheckStatusMessage(checkboxStatus);
-		})
-	})
+        // Set the initial checkbox status
+        chrome.storage.sync.set(checkboxStatus, () => {
+            // Send the checkbox status dynamically (callback function)
+            sendCheckStatusMessage(checkboxStatus);
+        })
+    })
 })
 
 const ztmPopupContainer = document.querySelector('.ztm-container');
@@ -37,13 +37,13 @@ const ztmPopupDarkModeIsEnabled = localStorage.getItem('ztmPopupDarkMode') === '
 ztmDarkModeCheckbox.checked = ztmPopupDarkModeIsEnabled
 
 const popupDarkMode = () => {
-	// Get the class list of the popup container
-	const containerClassList = ztmPopupContainer.classList
-	// If dark mode is enabled, add dark mode class
-	ztmDarkModeCheckbox.checked ? containerClassList.add('popup-darkmode') : containerClassList.remove('popup-darkmode');
+    // Get the class list of the popup container
+    const containerClassList = ztmPopupContainer.classList
+    // If dark mode is enabled, add dark mode class
+    ztmDarkModeCheckbox.checked ? containerClassList.add('popup-darkmode') : containerClassList.remove('popup-darkmode');
 
-	// Store the check status in local storage for popup dark mode
-	localStorage.setItem('ztmPopupDarkMode', ztmDarkModeCheckbox.checked);
+    // Store the check status in local storage for popup dark mode
+    localStorage.setItem('ztmPopupDarkMode', ztmDarkModeCheckbox.checked);
 };
 
 ztmDarkModeCheckbox.addEventListener('change', popupDarkMode);

--- a/popup/ztmDarkMode.js
+++ b/popup/ztmDarkMode.js
@@ -6,7 +6,7 @@
  */ 
 
 // Send the checkbox status to the active tab and current window
-const sendCheckStatusMessage = (checkboxStatus) => {
+var sendCheckStatusMessage = (checkboxStatus) => {
     // Get the active tab and current window
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
         // Send the checkbox status 
@@ -15,11 +15,11 @@ const sendCheckStatusMessage = (checkboxStatus) => {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    const ztmCheckbox = document.getElementById('ztmDarkModeCheckbox');
+    let ztmCheckbox = document.getElementById('ztmDarkModeCheckbox');
 
     ztmCheckbox.addEventListener('change', () => {
         // Get the checkbox status
-        const checkboxStatus = { 'ztmDarkModeCheckboxIsChecked' : ztmCheckbox.checked }
+        let checkboxStatus = { 'ztmDarkModeCheckboxIsChecked' : ztmCheckbox.checked }
 
         // Set the initial checkbox status
         chrome.storage.sync.set(checkboxStatus, () => {

--- a/popup/ztmHideLectureTitle.js
+++ b/popup/ztmHideLectureTitle.js
@@ -15,43 +15,32 @@ var sendCheckStatusMessage = (checkboxStatus) => {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    let ztmCheckbox = document.getElementById('ztmHideLectureTitleCheckbox');
+    let ztmHideLectureTitleCheckbox = document.getElementById('ztmHideLectureTitleCheckbox');
 
-    ztmCheckbox.addEventListener('change', () => {
+    const ztmHideLectureTitleIsEnabled = localStorage.getItem('ztmHideLectureTitle') === 'true'
+    ztmHideLectureTitleCheckbox.checked = ztmHideLectureTitleIsEnabled
+
+    ztmHideLectureTitleCheckbox.addEventListener('change', () => {
         // Get the checkbox status
-        let checkboxStatus = { 'ztmHideLectureTitleCheckboxIsChecked' : ztmCheckbox.checked }
+        let checkboxStatus = { 'ztmHideLectureTitleCheckboxIsChecked' : ztmHideLectureTitleCheckbox.checked }
 
         // Set the initial checkbox status
         chrome.storage.sync.set(checkboxStatus, () => {
             // Send the checkbox status dynamically (callback function)
             sendCheckStatusMessage(checkboxStatus);
         })
+
+        localStorage.setItem('ztmHideLectureTitle', ztmHideLectureTitleCheckbox.checked)
     })
 })
 
-const ztmHideLectureTitleCheckbox = document.getElementById('ztmHideLectureTitleCheckbox');
+// const ztmHideLectureTitleCheckbox = document.getElementById('ztmHideLectureTitleCheckbox');
 
-const ztmHideLectureTitleIsEnabled = localStorage.getItem('ztmHideLectureTitle') === 'true'
-ztmHideLectureTitleCheckbox.checked = ztmHideLectureTitleIsEnabled
+// const ztmHideLectureTitleIsEnabled = localStorage.getItem('ztmHideLectureTitle') === 'true'
+// ztmHideLectureTitleCheckbox.checked = ztmHideLectureTitleIsEnabled
 
-const ztmHideLectureTitle = () => {
-    localStorage.setItem('ztmHideLectureTitle', ztmHideLectureTitleCheckbox.checked)
-}
+// const ztmHideLectureTitle = () => {
+//     localStorage.setItem('ztmHideLectureTitle', ztmHideLectureTitleCheckbox.checked)
+// }
 
-ztmHideLectureTitleCheckbox.addEventListener('change', ztmHideLectureTitle);
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+// ztmHideLectureTitleCheckbox.addEventListener('change', ztmHideLectureTitle);

--- a/popup/ztmHideLectureTitle.js
+++ b/popup/ztmHideLectureTitle.js
@@ -1,0 +1,57 @@
+/* 
+ * Author: Sithu Khant
+ * GitHub: https://github.com/sithu-khant 
+ * Last Updated: Sun Jan 14, 2024
+ * Description: Hide the video lecture title 
+ */ 
+
+// Send the checkbox status to the active tab and current window
+var sendCheckStatusMessage = (checkboxStatus) => {
+    // Get the active tab and current window
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        // Send the checkbox status 
+        chrome.tabs.sendMessage(tabs[0].id, checkboxStatus);
+    })
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    let ztmCheckbox = document.getElementById('ztmHideLectureTitleCheckbox');
+
+    ztmCheckbox.addEventListener('change', () => {
+        // Get the checkbox status
+        let checkboxStatus = { 'ztmHideLectureTitleCheckboxIsChecked' : ztmCheckbox.checked }
+
+        // Set the initial checkbox status
+        chrome.storage.sync.set(checkboxStatus, () => {
+            // Send the checkbox status dynamically (callback function)
+            sendCheckStatusMessage(checkboxStatus);
+        })
+    })
+})
+
+const ztmHideLectureTitleCheckbox = document.getElementById('ztmHideLectureTitleCheckbox');
+
+const ztmHideLectureTitleIsEnabled = localStorage.getItem('ztmHideLectureTitle') === 'true'
+ztmHideLectureTitleCheckbox.checked = ztmHideLectureTitleIsEnabled
+
+const ztmHideLectureTitle = () => {
+    localStorage.setItem('ztmHideLectureTitle', ztmHideLectureTitleCheckbox.checked)
+}
+
+ztmHideLectureTitleCheckbox.addEventListener('change', ztmHideLectureTitle);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/popup/ztmSectionTime.js
+++ b/popup/ztmSectionTime.js
@@ -9,36 +9,36 @@
 // As the feature list grows, having all the code in popup.js will become hard to manage.
 
 // Function to query and send a message to the active tab
-function querySendTabMessage(options) {
-  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-    chrome.tabs.sendMessage(tabs[0].id, options);
-  });
-}
+// function querySendTabMessage(options) {
+//   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+//     chrome.tabs.sendMessage(tabs[0].id, options);
+//   });
+// }
 
 // Wait for the DOM content to be fully loaded before executing the code
-document.addEventListener("DOMContentLoaded", async () => {
-  // Get the checkbox element from the DOM
-  const sectionTimesCheckbox = document.getElementById(
-    "ztmSectionTimesCheckbox"
-  );
+// document.addEventListener("DOMContentLoaded", async () => {
+//   // Get the checkbox element from the DOM
+//   const sectionTimesCheckbox = document.getElementById(
+//     "ztmSectionTimesCheckbox"
+//   );
 
-  // Retrieve the stored checkbox state from Chrome storage
-  const data = await chrome.storage.sync.get(
-    "ztmSectionTimesCheckboxIsChecked"
-  );
+//   // Retrieve the stored checkbox state from Chrome storage
+//   const data = await chrome.storage.sync.get(
+//     "ztmSectionTimesCheckboxIsChecked"
+//   );
 
-  // Set the checkbox state based on the retrieved data (or default to false)
-  sectionTimesCheckbox.checked = data.ztmSectionTimesCheckboxIsChecked || false;
+//   // Set the checkbox state based on the retrieved data (or default to false)
+//   sectionTimesCheckbox.checked = data.ztmSectionTimesCheckboxIsChecked || false;
 
-  sectionTimesCheckbox.addEventListener("change", function () {
-    chrome.storage.sync.set(
-      { ztmSectionTimesCheckboxIsChecked: sectionTimesCheckbox.checked },
-      function () {
-        // Send a message to the active tab with the updated checkbox state
-        querySendTabMessage({
-          ztmSectionTimesCheckboxIsChecked: sectionTimesCheckbox.checked,
-        });
-      }
-    );
-  });
-});
+//   sectionTimesCheckbox.addEventListener("change", function () {
+//     chrome.storage.sync.set(
+//       { ztmSectionTimesCheckboxIsChecked: sectionTimesCheckbox.checked },
+//       function () {
+//         // Send a message to the active tab with the updated checkbox state
+//         querySendTabMessage({
+//           ztmSectionTimesCheckboxIsChecked: sectionTimesCheckbox.checked,
+//         });
+//       }
+//     );
+//   });
+// });

--- a/scripts/ztm-hide-lecture-title.js
+++ b/scripts/ztm-hide-lecture-title.js
@@ -1,0 +1,42 @@
+/* 
+ * Author: Sithu Khant
+ * GitHub: https://github.com/sithu-khant 
+ * Last Updated: Sun Jan 14, 2024
+ * Description: Hide the video lecture title 
+ */ 
+
+const ztmHideLectureTitle = () => {
+	const hideLectureTitle = (isChecked) => {
+		// Get the lecture attachement
+		const lectureAttachment = document.querySelector('.lecture-attachment');
+		// Check it is video lecture type or not
+		const isVideoLectureType =  lectureAttachment.classList.contains('lecture-attachment-type-video');
+
+		// Get the lecture title
+		const ztmVideoLectureTitle = document.getElementById('lecture_heading');
+
+		if (isVideoLectureType && isChecked) {
+			ztmVideoLectureTitle.style.display = 'none';
+		} else {
+			ztmVideoLectureTitle.style.display = 'block';
+		};
+	};
+
+	// Get the initial checkbox status and apply style
+	chrome.storage.sync.get('ztmHideLectureTitleCheckboxIsChecked', (data) => {
+	    let isChecked = data.ztmHideLectureTitleCheckboxIsChecked || false;
+	    hideLectureTitle(isChecked);
+	})
+
+	// Get the checkbox status dynamically and apply style
+	chrome.storage.onChanged.addListener((changes, namespace) => {
+	    if (namespace === 'sync' && 'ztmHideLectureTitleCheckboxIsChecked' in changes) {
+	        let isChecked = changes.ztmHideLectureTitleCheckboxIsChecked.newValue || false;
+	        hideLectureTitle(isChecked);
+	    }
+	});
+}
+
+// Track the page for every new lecture  
+const ztmHideLectureTitleObserver = new MutationObserver(() => ztmHideLectureTitle());
+ztmHideLectureTitleObserver.observe(document.body, { childList: true, subtree: true })

--- a/scripts/ztm-hide-lecture-title.js
+++ b/scripts/ztm-hide-lecture-title.js
@@ -5,23 +5,20 @@
  * Description: Hide the video lecture title 
  */ 
 
+const hideLectureTitle = (isChecked) => {
+	// Get the lecture attachement
+	const lectureAttachment = document.querySelector('.lecture-attachment');
+	// Check it is video lecture type or not
+	const isVideoLectureType =  lectureAttachment.classList.contains('lecture-attachment-type-video');
+
+	// Get the lecture title
+	const ztmVideoLectureTitle = document.getElementById('lecture_heading');
+
+	// Apply style to lecture title display
+	ztmVideoLectureTitle.style.display = isVideoLectureType && isChecked ? 'none' : 'block';
+};
+
 const ztmHideLectureTitle = () => {
-	const hideLectureTitle = (isChecked) => {
-		// Get the lecture attachement
-		const lectureAttachment = document.querySelector('.lecture-attachment');
-		// Check it is video lecture type or not
-		const isVideoLectureType =  lectureAttachment.classList.contains('lecture-attachment-type-video');
-
-		// Get the lecture title
-		const ztmVideoLectureTitle = document.getElementById('lecture_heading');
-
-		if (isVideoLectureType && isChecked) {
-			ztmVideoLectureTitle.style.display = 'none';
-		} else {
-			ztmVideoLectureTitle.style.display = 'block';
-		};
-	};
-
 	// Get the initial checkbox status and apply style
 	chrome.storage.sync.get('ztmHideLectureTitleCheckboxIsChecked', (data) => {
 	    let isChecked = data.ztmHideLectureTitleCheckboxIsChecked || false;

--- a/scripts/ztm-hide-lecture-title.js
+++ b/scripts/ztm-hide-lecture-title.js
@@ -5,35 +5,41 @@
  * Description: Hide the video lecture title 
  */ 
 
-const hideLectureTitle = (isChecked) => {
-	// Get the lecture attachement
-	const lectureAttachment = document.querySelector('.lecture-attachment');
-	// Check it is video lecture type or not
-	const isVideoLectureType =  lectureAttachment.classList.contains('lecture-attachment-type-video');
+// Get the home back icon
+const lectureTitleHomeBackIcon = document.querySelector('.nav-icon-back');
 
-	// Get the lecture title
-	const ztmVideoLectureTitle = document.getElementById('lecture_heading');
+// Only run the script if there is home back icon
+if (lectureTitleHomeBackIcon) {
+	const hideLectureTitle = (isChecked) => {
+		// Get the lecture attachement
+		const lectureAttachment = document.querySelector('.lecture-attachment');
+		// Check it is video lecture type or not
+		const isVideoLectureType =  lectureAttachment.classList.contains('lecture-attachment-type-video');
 
-	// Apply style to lecture title display
-	ztmVideoLectureTitle.style.display = isVideoLectureType && isChecked ? 'none' : 'block';
-};
+		// Get the lecture title
+		const ztmVideoLectureTitle = document.getElementById('lecture_heading');
 
-const ztmHideLectureTitle = () => {
-	// Get the initial checkbox status and apply style
-	chrome.storage.sync.get('ztmHideLectureTitleCheckboxIsChecked', (data) => {
-	    let isChecked = data.ztmHideLectureTitleCheckboxIsChecked || false;
-	    hideLectureTitle(isChecked);
-	})
+		// Apply style to lecture title display
+		ztmVideoLectureTitle.style.display = isVideoLectureType && isChecked ? 'none' : 'block';
+	};
 
-	// Get the checkbox status dynamically and apply style
-	chrome.storage.onChanged.addListener((changes, namespace) => {
-	    if (namespace === 'sync' && 'ztmHideLectureTitleCheckboxIsChecked' in changes) {
-	        let isChecked = changes.ztmHideLectureTitleCheckboxIsChecked.newValue || false;
-	        hideLectureTitle(isChecked);
-	    }
-	});
+	const ztmHideLectureTitle = () => {
+		// Get the initial checkbox status and apply style
+		chrome.storage.sync.get('ztmHideLectureTitleCheckboxIsChecked', (data) => {
+		    let isChecked = data.ztmHideLectureTitleCheckboxIsChecked || false;
+		    hideLectureTitle(isChecked);
+		})
+
+		// Get the checkbox status dynamically and apply style
+		chrome.storage.onChanged.addListener((changes, namespace) => {
+		    if (namespace === 'sync' && 'ztmHideLectureTitleCheckboxIsChecked' in changes) {
+		        let isChecked = changes.ztmHideLectureTitleCheckboxIsChecked.newValue || false;
+		        hideLectureTitle(isChecked);
+		    }
+		});
+	}
+
+	// Track the page for every new lecture  
+	const ztmHideLectureTitleObserver = new MutationObserver(() => ztmHideLectureTitle());
+	ztmHideLectureTitleObserver.observe(document.body, { childList: true, subtree: true })
 }
-
-// Track the page for every new lecture  
-const ztmHideLectureTitleObserver = new MutationObserver(() => ztmHideLectureTitle());
-ztmHideLectureTitleObserver.observe(document.body, { childList: true, subtree: true })

--- a/scripts/ztm-section-times.js
+++ b/scripts/ztm-section-times.js
@@ -5,144 +5,146 @@
  * Description: Adds lecture time statistics to each section and the sidebar
  */
 
-// Get the back link icon
-const sectionTimesBackLinkIcon = document.querySelector('.nav-back-link');
+// // Get the back link icon
+// const sectionTimesBackLinkIcon = document.querySelector('.nav-back-link');
 
-// The function will only work on the course info page,
-// Cause `sectionTimesBackLinkIcon` exists on the course info page.
-if (sectionTimesBackLinkIcon) {
+// // The function will only work on the course info page,
+// // Cause `sectionTimesBackLinkIcon` exists on the course info page.
+// if (sectionTimesBackLinkIcon) {
 
-    // Helper function to format the lecture status
-    const statusFormatter = (status) => status?.toLowerCase().includes("completed") ? "complete" : "incomplete";
+//     // Helper function to format the lecture status
+//     const statusFormatter = (status) => status?.toLowerCase().includes("completed") ? "complete" : "incomplete";
 
-    // Helper function to convert seconds to a formatted time string
-    const secondsToTime = (seconds) => {
-        const hours = Math.floor(seconds / 3600);
-        const minutes = Math.floor((seconds % 3600) / 60);
-        const remainingSeconds = seconds % 60;
-        return hours > 0 ? `${hours}h ${minutes}m ${remainingSeconds}s` : `${minutes}m ${remainingSeconds}s`;
-    };
+//     // Helper function to convert seconds to a formatted time string
+//     const secondsToTime = (seconds) => {
+//         const hours = Math.floor(seconds / 3600);
+//         const minutes = Math.floor((seconds % 3600) / 60);
+//         const remainingSeconds = seconds % 60;
+//         return hours > 0 ? `${hours}h ${minutes}m ${remainingSeconds}s` : `${minutes}m ${remainingSeconds}s`;
+//     };
 
-    // Function to update the section times and badges
-    const updateSectionTimes = () => {
-        const containers = document.querySelectorAll(".course-section");
+//     // Function to update the section times and badges
+//     const updateSectionTimes = () => {
+//         const containers = document.querySelectorAll(".course-section");
 
-        const allAnchorsArray = [];
-        const sectionTimes = { totalTime: 0, totalWatched: 0 };
+//         const allAnchorsArray = [];
+//         const sectionTimes = { totalTime: 0, totalWatched: 0 };
 
-        containers.forEach((container) => {
-            const anchors = Array.from(container.querySelectorAll("a"));
+//         containers.forEach((container) => {
+//             const anchors = Array.from(container.querySelectorAll("a"));
 
-            anchors.forEach((a) => {
-                const lectureTitle = a.children[1].innerText;
-                const matchTime = lectureTitle.match(/\((\d{1,2}\s*:\s*\d{1,2}\s*)\)/);
-                const rawTime = matchTime ? matchTime[1].replaceAll(" ", "") : "0:0";
-                const timeInSecs = rawTime.split(":").reduce((acc, time) => acc * 60 + parseInt(time, 10), 0);
+//             anchors.forEach((a) => {
+//                 const lectureTitle = a.children[1].innerText;
+//                 const matchTime = lectureTitle.match(/\((\d{1,2}\s*:\s*\d{1,2}\s*)\)/);
+//                 const rawTime = matchTime ? matchTime[1].replaceAll(" ", "") : "0:0";
+//                 const timeInSecs = rawTime.split(":").reduce((acc, time) => acc * 60 + parseInt(time, 10), 0);
 
-                const sectionTitle = container.children[0].innerText;
-                const lectureStatus = statusFormatter(a.children[0].ariaLabel);
+//                 const sectionTitle = container.children[0].innerText;
+//                 const lectureStatus = statusFormatter(a.children[0].ariaLabel);
 
-                allAnchorsArray.push({
-                    section: sectionTitle,
-                    status: lectureStatus,
-                    title: lectureTitle,
-                    rawTime: rawTime,
-                    timeInSecs: timeInSecs,
-                    element: container,
-                });
+//                 allAnchorsArray.push({
+//                     section: sectionTitle,
+//                     status: lectureStatus,
+//                     title: lectureTitle,
+//                     rawTime: rawTime,
+//                     timeInSecs: timeInSecs,
+//                     element: container,
+//                 });
 
-                if (!sectionTimes[sectionTitle]) {
-                    sectionTimes[sectionTitle] = { total: 0, watched: 0 };
-                }
-                sectionTimes[sectionTitle].total += timeInSecs;
-                if (lectureStatus === "complete") sectionTimes[sectionTitle].watched += timeInSecs;
+//                 if (!sectionTimes[sectionTitle]) {
+//                     sectionTimes[sectionTitle] = { total: 0, watched: 0 };
+//                 }
+//                 sectionTimes[sectionTitle].total += timeInSecs;
+//                 if (lectureStatus === "complete") sectionTimes[sectionTitle].watched += timeInSecs;
 
-                sectionTimes.totalTime += timeInSecs;
-                if (lectureStatus === "complete") sectionTimes.totalWatched += timeInSecs;
-            });
-        });
+//                 sectionTimes.totalTime += timeInSecs;
+//                 if (lectureStatus === "complete") sectionTimes.totalWatched += timeInSecs;
+//             });
+//         });
 
-        Array.from(containers).forEach((cont) => {
-            const alreadyHasTitleSect = cont.children[0].querySelector(".sect-title");
-            const sectionTitle = alreadyHasTitleSect ? alreadyHasTitleSect.innerText : cont.children[0].innerText;
+//         Array.from(containers).forEach((cont) => {
+//             const alreadyHasTitleSect = cont.children[0].querySelector(".sect-title");
+//             const sectionTitle = alreadyHasTitleSect ? alreadyHasTitleSect.innerText : cont.children[0].innerText;
 
-            const data = sectionTimes[sectionTitle];
-            const watchedTime = secondsToTime(data?.watched || 0);
-            const totalTime = secondsToTime(data?.total || 0);
+//             const data = sectionTimes[sectionTitle];
+//             const watchedTime = secondsToTime(data?.watched || 0);
+//             const totalTime = secondsToTime(data?.total || 0);
 
-            cont.children[0].innerHTML = `
-                <div class="sect-container">
-                    <div class="sect-title">${sectionTitle}</div>
-                    <div class="sect-watchtime">
-                        <div class="badge">
-                            <span class="badge-prefix">Watched</span>
-                            <span class="badge-text">${watchedTime}</span>
-                        </div>
-                        <div class="badge">
-                            <span class="badge-prefix">Total</span>
-                            <span class="badge-text">${totalTime}</span>
-                        </div>
-                    </div>
-                </div>`;
-        });
+//             cont.children[0].innerHTML = `
+//                 <div class="sect-container">
+//                     <div class="sect-title">${sectionTitle}</div>
+//                     <div class="sect-watchtime">
+//                         <div class="badge">
+//                             <span class="badge-prefix">Watched</span>
+//                             <span class="badge-text">${watchedTime}</span>
+//                         </div>
+//                         <div class="badge">
+//                             <span class="badge-prefix">Total</span>
+//                             <span class="badge-text">${totalTime}</span>
+//                         </div>
+//                     </div>
+//                 </div>`;
+//         });
 
-        const existingSidebar = document.querySelector(".sidebar-times");
+//         const existingSidebar = document.querySelector(".sidebar-times");
 
-        if (!existingSidebar) {
-            const sidebar = document.querySelector(".course-progress");
-            const newDiv = document.createElement("div");
-            const watchedTime = secondsToTime(sectionTimes.totalWatched || 0);
-            const totalTime = secondsToTime(sectionTimes.totalTime || 0);
-            const left = secondsToTime(sectionTimes.totalTime - sectionTimes.totalWatched);
+//         if (!existingSidebar) {
+//             const sidebar = document.querySelector(".course-progress");
+//             const newDiv = document.createElement("div");
+//             const watchedTime = secondsToTime(sectionTimes.totalWatched || 0);
+//             const totalTime = secondsToTime(sectionTimes.totalTime || 0);
+//             const left = secondsToTime(sectionTimes.totalTime - sectionTimes.totalWatched);
 
-            newDiv.innerHTML = `
-                <div class="sidebar-times">
-                    <div class="badge">
-                        <span class="badge-prefix">Course Length</span>
-                        <span class="badge-text">${totalTime}</span>
-                    </div>
-                    <div class="badge">
-                        <span class="badge-prefix">Total Watched</span>
-                        <span class="badge-text">${watchedTime}</span>
-                    </div>
-                    <div class="badge">
-                        <span class="badge-prefix">Total Left</span>
-                        <span class="badge-text">${left}</span>
-                    </div>
-                </div>`;
-            sidebar.insertAdjacentElement("afterend", newDiv);
-        }
-    };
+//             newDiv.innerHTML = `
+//                 <div class="sidebar-times">
+//                     <div class="badge">
+//                         <span class="badge-prefix">Course Length</span>
+//                         <span class="badge-text">${totalTime}</span>
+//                     </div>
+//                     <div class="badge">
+//                         <span class="badge-prefix">Total Watched</span>
+//                         <span class="badge-text">${watchedTime}</span>
+//                     </div>
+//                     <div class="badge">
+//                         <span class="badge-prefix">Total Left</span>
+//                         <span class="badge-text">${left}</span>
+//                     </div>
+//                 </div>`;
+//             sidebar.insertAdjacentElement("afterend", newDiv);
+//         }
+//     };
 
-    const updateFunctionality = (isEnabled) => {
-        if (!isEnabled) {
-            const elementsToRemove = [
-                ...document.querySelectorAll(".sect-watchtime"),
-                ...document.querySelectorAll(".sidebar-times"),
-            ];
+//     const updateFunctionality = (isEnabled) => {
+//         if (!isEnabled) {
+//             const elementsToRemove = [
+//                 ...document.querySelectorAll(".sect-watchtime"),
+//                 ...document.querySelectorAll(".sidebar-times"),
+//             ];
 
-            elementsToRemove.forEach((element) => {
-                element.parentNode.removeChild(element);
-            });
-            return;
-        }
+//             elementsToRemove.forEach((element) => {
+//                 element.parentNode.removeChild(element);
+//             });
+//             return;
+//         }
 
-        updateSectionTimes();
-    };
+//         updateSectionTimes();
+//     };
 
-    const ztmSectionTimesObserver = new MutationObserver(() => {
-        chrome.storage.sync.get("ztmSectionTimesCheckboxIsChecked", (data) => {
-            const isEnabled = data?.ztmSectionTimesCheckboxIsChecked || false;
-            updateFunctionality(isEnabled);
-        });
+//     const ztmSectionTimesObserver = new MutationObserver(() => {
+//         chrome.storage.sync.get("ztmSectionTimesCheckboxIsChecked", (data) => {
+//             const isEnabled = data?.ztmSectionTimesCheckboxIsChecked || false;
+//             updateFunctionality(isEnabled);
+//         });
 
-        chrome.storage.onChanged.addListener((changes, namespace) => {
-            if (namespace === "sync" && "ztmSectionTimesCheckboxIsChecked" in changes) {
-                const value = changes.ztmSectionTimesCheckboxIsChecked.newValue || false;
-                updateFunctionality(value);
-            }
-        });
-    });
+//         console.log('section time observer is running...');
 
-    ztmSectionTimesObserver.observe(document.body, { childList: true, subtree: true });
-}
+//         chrome.storage.onChanged.addListener((changes, namespace) => {
+//             if (namespace === "sync" && "ztmSectionTimesCheckboxIsChecked" in changes) {
+//                 const value = changes.ztmSectionTimesCheckboxIsChecked.newValue || false;
+//                 updateFunctionality(value);
+//             }
+//         });
+//     });
+
+//     ztmSectionTimesObserver.observe(document.body, { childList: true, subtree: true });
+// }

--- a/scripts/ztm-section-times.js
+++ b/scripts/ztm-section-times.js
@@ -7,85 +7,91 @@
 
 // Helper function to format the lecture status
 const statusFormatter = (status) =>
-  status?.toLowerCase().includes("completed") ? "complete" : "incomplete";
+    status?.toLowerCase().includes("completed") ? "complete" : "incomplete";
 
 // Helper function to convert seconds to a formatted time string
 const secondsToTime = (seconds) => {
-  const hours = Math.floor(seconds / 3600);
-  const minutes = Math.floor((seconds % 3600) / 60);
-  const remainingSeconds = seconds % 60;
-  return hours > 0
-    ? `${hours}h ${minutes}m ${remainingSeconds}s`
-    : `${minutes}m ${remainingSeconds}s`;
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const remainingSeconds = seconds % 60;
+    return hours > 0
+        ? `${hours}h ${minutes}m ${remainingSeconds}s`
+        : `${minutes}m ${remainingSeconds}s`;
 };
 
 // Function to update the section times and badges
 const updateSectionTimes = () => {
-  // Get all containers with the class .course-section
-  const containers = document.querySelectorAll(".course-section");
+    // Get all containers with the class .course-section
+    const containers = document.querySelectorAll(".course-section");
 
-  // Initialize an array to store all anchor information for each section
-  const allAnchorsArray = [];
+    // Initialize an array to store all anchor information for each section
+    const allAnchorsArray = [];
 
-  // Object to store total times for each section and overall
-  const sectionTimes = { totalTime: 0, totalWatched: 0 };
+    // Object to store total times for each section and overall
+    const sectionTimes = { totalTime: 0, totalWatched: 0 };
 
-  // Loop through each container
-  containers.forEach((container) => {
-    // Get all anchor elements within the current container
-    const anchors = Array.from(container.querySelectorAll("a"));
+    // Loop through each container
+    containers.forEach((container) => {
+        // Get all anchor elements within the current container
+        const anchors = Array.from(container.querySelectorAll("a"));
 
-    // Loop through each anchor
-    anchors.forEach((a) => {
-      // Extract relevant information from the anchor
-      const lectureTitle = a.children[1].innerText;
-      const matchTime = lectureTitle.match(/\((\d{1,2}\s*:\s*\d{1,2}\s*)\)/);
-      const rawTime = matchTime ? matchTime[1].replaceAll(" ", "") : "0:0";
-      const timeInSecs = rawTime
-        .split(":")
-        .reduce((acc, time) => acc * 60 + parseInt(time, 10), 0);
+        // Loop through each anchor
+        anchors.forEach((a) => {
+            // Extract relevant information from the anchor
+            const lectureTitle = a.children[1].innerText;
+            const matchTime = lectureTitle.match(
+                /\((\d{1,2}\s*:\s*\d{1,2}\s*)\)/,
+            );
+            const rawTime = matchTime
+                ? matchTime[1].replaceAll(" ", "")
+                : "0:0";
+            const timeInSecs = rawTime
+                .split(":")
+                .reduce((acc, time) => acc * 60 + parseInt(time, 10), 0);
 
-      // Extract section title and lecture status
-      const sectionTitle = container.children[0].innerText;
-      const lectureStatus = statusFormatter(a.children[0].ariaLabel);
+            // Extract section title and lecture status
+            const sectionTitle = container.children[0].innerText;
+            const lectureStatus = statusFormatter(a.children[0].ariaLabel);
 
-      // Store anchor information in the array
-      allAnchorsArray.push({
-        section: sectionTitle,
-        status: lectureStatus,
-        title: lectureTitle,
-        rawTime: rawTime,
-        timeInSecs: timeInSecs,
-        element: container,
-      });
+            // Store anchor information in the array
+            allAnchorsArray.push({
+                section: sectionTitle,
+                status: lectureStatus,
+                title: lectureTitle,
+                rawTime: rawTime,
+                timeInSecs: timeInSecs,
+                element: container,
+            });
 
-      // Update section times object
-      if (!sectionTimes[sectionTitle]) {
-        sectionTimes[sectionTitle] = { total: 0, watched: 0 };
-      }
-      sectionTimes[sectionTitle].total += timeInSecs;
-      if (lectureStatus === "complete")
-        sectionTimes[sectionTitle].watched += timeInSecs;
+            // Update section times object
+            if (!sectionTimes[sectionTitle]) {
+                sectionTimes[sectionTitle] = { total: 0, watched: 0 };
+            }
+            sectionTimes[sectionTitle].total += timeInSecs;
+            if (lectureStatus === "complete")
+                sectionTimes[sectionTitle].watched += timeInSecs;
 
-      // Update overall times
-      sectionTimes.totalTime += timeInSecs;
-      if (lectureStatus === "complete") sectionTimes.totalWatched += timeInSecs;
+            // Update overall times
+            sectionTimes.totalTime += timeInSecs;
+            if (lectureStatus === "complete")
+                sectionTimes.totalWatched += timeInSecs;
+        });
     });
-  });
 
-  // Update HTML for each container based on the calculated times
-  Array.from(containers).forEach((cont) => {
-    const alreadyHasTitleSect = cont.children[0].querySelector(".sect-title");
+    // Update HTML for each container based on the calculated times
+    Array.from(containers).forEach((cont) => {
+        const alreadyHasTitleSect =
+            cont.children[0].querySelector(".sect-title");
 
-    const sectionTitle = alreadyHasTitleSect
-      ? alreadyHasTitleSect.innerText
-      : cont.children[0].innerText;
+        const sectionTitle = alreadyHasTitleSect
+            ? alreadyHasTitleSect.innerText
+            : cont.children[0].innerText;
 
-    const data = sectionTimes[sectionTitle];
-    const watchedTime = secondsToTime(data?.watched || 0);
-    const totalTime = secondsToTime(data?.total || 0);
+        const data = sectionTimes[sectionTitle];
+        const watchedTime = secondsToTime(data?.watched || 0);
+        const totalTime = secondsToTime(data?.total || 0);
 
-    cont.children[0].innerHTML = `
+        cont.children[0].innerHTML = `
       <div class="sect-container">
         <div class="sect-title">${sectionTitle}</div>
         <div class="sect-watchtime">
@@ -99,21 +105,21 @@ const updateSectionTimes = () => {
           </div>
         </div>
       </div>`;
-  });
+    });
 
-  const existingSidebar = document.querySelector(".sidebar-times");
+    const existingSidebar = document.querySelector(".sidebar-times");
 
-  if (!existingSidebar) {
-    // Update sidebar with overall course times
-    const sidebar = document.querySelector(".course-progress");
-    const newDiv = document.createElement("div");
-    const watchedTime = secondsToTime(sectionTimes.totalWatched || 0);
-    const totalTime = secondsToTime(sectionTimes.totalTime || 0);
-    const left = secondsToTime(
-      sectionTimes.totalTime - sectionTimes.totalWatched
-    );
+    if (!existingSidebar) {
+        // Update sidebar with overall course times
+        const sidebar = document.querySelector(".course-progress");
+        const newDiv = document.createElement("div");
+        const watchedTime = secondsToTime(sectionTimes.totalWatched || 0);
+        const totalTime = secondsToTime(sectionTimes.totalTime || 0);
+        const left = secondsToTime(
+            sectionTimes.totalTime - sectionTimes.totalWatched,
+        );
 
-    newDiv.innerHTML = `
+        newDiv.innerHTML = `
     <div class="sidebar-times">
       <div class="badge">
         <span class="badge-prefix">Course Length</span>
@@ -128,51 +134,53 @@ const updateSectionTimes = () => {
         <span class="badge-text">${left}</span>
       </div>
     </div>`;
-    sidebar.insertAdjacentElement("afterend", newDiv);
-  }
+        sidebar.insertAdjacentElement("afterend", newDiv);
+    }
 };
 
 // Function to enable/disable functionality based on Chrome storage
 const updateFunctionality = (isEnabled) => {
-  if (!isEnabled) {
-    // Remove existing elements related to functionality
-    const elementsToRemove = [
-      ...document.querySelectorAll(".sect-watchtime"),
-      ...document.querySelectorAll(".sidebar-times"),
-    ];
+    if (!isEnabled) {
+        // Remove existing elements related to functionality
+        const elementsToRemove = [
+            ...document.querySelectorAll(".sect-watchtime"),
+            ...document.querySelectorAll(".sidebar-times"),
+        ];
 
-    elementsToRemove.forEach((element) => {
-      element.parentNode.removeChild(element);
-    });
-    return;
-  }
+        elementsToRemove.forEach((element) => {
+            element.parentNode.removeChild(element);
+        });
+        return;
+    }
 
-  // Call the function to update section times and badges
-  updateSectionTimes();
+    // Call the function to update section times and badges
+    updateSectionTimes();
 };
 
 // Listen for changes in Chrome storage
 chrome.storage.onChanged.addListener((changes, namespace) => {
-  if (namespace === "sync" && "ztmSectionTimesCheckboxIsChecked" in changes) {
-    const value = changes.ztmSectionTimesCheckboxIsChecked.newValue || false;
-    // Update functionality based on the changed value
-    updateFunctionality(value);
-  }
+    if (namespace === "sync" && "ztmSectionTimesCheckboxIsChecked" in changes) {
+        const value =
+            changes.ztmSectionTimesCheckboxIsChecked.newValue || false;
+        // Update functionality based on the changed value
+        updateFunctionality(value);
+    }
 });
 
 // Use arrow function for MutationObserver
 const observer = new MutationObserver((mutations) => {
-  const existingSidebarTimes = document.querySelector(".sidebar-times");
-  const existingSectCont = document.querySelector(".sect-container");
-  const isRightPage = window.location.pathname.includes("courses/enrolled");
+    const existingSidebarTimes = document.querySelector(".sidebar-times");
+    const existingSectCont = document.querySelector(".sect-container");
+    const isRightPage = window.location.pathname.includes("courses/enrolled");
 
-  isRightPage &&
-    chrome.storage.sync.get("ztmSectionTimesCheckboxIsChecked", (data) => {
-      const isEnabled = data?.ztmSectionTimesCheckboxIsChecked || false;
-      // Call the updateFunctionality with the retrieved isEnabled state
-      if (!existingSectCont && !existingSidebarTimes && isRightPage)
-        updateFunctionality(isEnabled);
-    });
+    isRightPage &&
+        chrome.storage.sync.get("ztmSectionTimesCheckboxIsChecked", (data) => {
+            const isEnabled = data?.ztmSectionTimesCheckboxIsChecked || false;
+            // Call the updateFunctionality with the retrieved isEnabled state
+            if (!existingSectCont && !existingSidebarTimes && isRightPage) {
+                updateFunctionality(isEnabled);
+            }
+        });
 });
 
 // Use arrow function for observer.observe

--- a/scripts/ztm-section-times.js
+++ b/scripts/ztm-section-times.js
@@ -130,19 +130,19 @@ if (sectionTimesBackLinkIcon) {
         updateSectionTimes();
     };
 
-    chrome.storage.onChanged.addListener((changes, namespace) => {
-        if (namespace === "sync" && "ztmSectionTimesCheckboxIsChecked" in changes) {
-            const value = changes.ztmSectionTimesCheckboxIsChecked.newValue || false;
-            updateFunctionality(value);
-        }
-    });
-
-    const ztmSectionTimesObserver = new MutationObserver((mutations) => {
+    const ztmSectionTimesObserver = new MutationObserver(() => {
         chrome.storage.sync.get("ztmSectionTimesCheckboxIsChecked", (data) => {
             const isEnabled = data?.ztmSectionTimesCheckboxIsChecked || false;
             updateFunctionality(isEnabled);
         });
+
+        chrome.storage.onChanged.addListener((changes, namespace) => {
+            if (namespace === "sync" && "ztmSectionTimesCheckboxIsChecked" in changes) {
+                const value = changes.ztmSectionTimesCheckboxIsChecked.newValue || false;
+                updateFunctionality(value);
+            }
+        });
     });
 
-    ztmSectionTimesObserver.observe(document.documentElement, { childList: true, subtree: true });
+    ztmSectionTimesObserver.observe(document.body, { childList: true, subtree: true });
 }

--- a/scripts/ztm-section-times.js
+++ b/scripts/ztm-section-times.js
@@ -5,183 +5,144 @@
  * Description: Adds lecture time statistics to each section and the sidebar
  */
 
-// Helper function to format the lecture status
-const statusFormatter = (status) =>
-    status?.toLowerCase().includes("completed") ? "complete" : "incomplete";
+// Get the back link icon
+const sectionTimesBackLinkIcon = document.querySelector('.nav-back-link');
 
-// Helper function to convert seconds to a formatted time string
-const secondsToTime = (seconds) => {
-    const hours = Math.floor(seconds / 3600);
-    const minutes = Math.floor((seconds % 3600) / 60);
-    const remainingSeconds = seconds % 60;
-    return hours > 0
-        ? `${hours}h ${minutes}m ${remainingSeconds}s`
-        : `${minutes}m ${remainingSeconds}s`;
-};
+// The function will only work on the course info page,
+// Cause `sectionTimesBackLinkIcon` exists on the course info page.
+if (sectionTimesBackLinkIcon) {
 
-// Function to update the section times and badges
-const updateSectionTimes = () => {
-    // Get all containers with the class .course-section
-    const containers = document.querySelectorAll(".course-section");
+    // Helper function to format the lecture status
+    const statusFormatter = (status) => status?.toLowerCase().includes("completed") ? "complete" : "incomplete";
 
-    // Initialize an array to store all anchor information for each section
-    const allAnchorsArray = [];
+    // Helper function to convert seconds to a formatted time string
+    const secondsToTime = (seconds) => {
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        const remainingSeconds = seconds % 60;
+        return hours > 0 ? `${hours}h ${minutes}m ${remainingSeconds}s` : `${minutes}m ${remainingSeconds}s`;
+    };
 
-    // Object to store total times for each section and overall
-    const sectionTimes = { totalTime: 0, totalWatched: 0 };
+    // Function to update the section times and badges
+    const updateSectionTimes = () => {
+        const containers = document.querySelectorAll(".course-section");
 
-    // Loop through each container
-    containers.forEach((container) => {
-        // Get all anchor elements within the current container
-        const anchors = Array.from(container.querySelectorAll("a"));
+        const allAnchorsArray = [];
+        const sectionTimes = { totalTime: 0, totalWatched: 0 };
 
-        // Loop through each anchor
-        anchors.forEach((a) => {
-            // Extract relevant information from the anchor
-            const lectureTitle = a.children[1].innerText;
-            const matchTime = lectureTitle.match(
-                /\((\d{1,2}\s*:\s*\d{1,2}\s*)\)/,
-            );
-            const rawTime = matchTime
-                ? matchTime[1].replaceAll(" ", "")
-                : "0:0";
-            const timeInSecs = rawTime
-                .split(":")
-                .reduce((acc, time) => acc * 60 + parseInt(time, 10), 0);
+        containers.forEach((container) => {
+            const anchors = Array.from(container.querySelectorAll("a"));
 
-            // Extract section title and lecture status
-            const sectionTitle = container.children[0].innerText;
-            const lectureStatus = statusFormatter(a.children[0].ariaLabel);
+            anchors.forEach((a) => {
+                const lectureTitle = a.children[1].innerText;
+                const matchTime = lectureTitle.match(/\((\d{1,2}\s*:\s*\d{1,2}\s*)\)/);
+                const rawTime = matchTime ? matchTime[1].replaceAll(" ", "") : "0:0";
+                const timeInSecs = rawTime.split(":").reduce((acc, time) => acc * 60 + parseInt(time, 10), 0);
 
-            // Store anchor information in the array
-            allAnchorsArray.push({
-                section: sectionTitle,
-                status: lectureStatus,
-                title: lectureTitle,
-                rawTime: rawTime,
-                timeInSecs: timeInSecs,
-                element: container,
+                const sectionTitle = container.children[0].innerText;
+                const lectureStatus = statusFormatter(a.children[0].ariaLabel);
+
+                allAnchorsArray.push({
+                    section: sectionTitle,
+                    status: lectureStatus,
+                    title: lectureTitle,
+                    rawTime: rawTime,
+                    timeInSecs: timeInSecs,
+                    element: container,
+                });
+
+                if (!sectionTimes[sectionTitle]) {
+                    sectionTimes[sectionTitle] = { total: 0, watched: 0 };
+                }
+                sectionTimes[sectionTitle].total += timeInSecs;
+                if (lectureStatus === "complete") sectionTimes[sectionTitle].watched += timeInSecs;
+
+                sectionTimes.totalTime += timeInSecs;
+                if (lectureStatus === "complete") sectionTimes.totalWatched += timeInSecs;
             });
-
-            // Update section times object
-            if (!sectionTimes[sectionTitle]) {
-                sectionTimes[sectionTitle] = { total: 0, watched: 0 };
-            }
-            sectionTimes[sectionTitle].total += timeInSecs;
-            if (lectureStatus === "complete")
-                sectionTimes[sectionTitle].watched += timeInSecs;
-
-            // Update overall times
-            sectionTimes.totalTime += timeInSecs;
-            if (lectureStatus === "complete")
-                sectionTimes.totalWatched += timeInSecs;
         });
+
+        Array.from(containers).forEach((cont) => {
+            const alreadyHasTitleSect = cont.children[0].querySelector(".sect-title");
+            const sectionTitle = alreadyHasTitleSect ? alreadyHasTitleSect.innerText : cont.children[0].innerText;
+
+            const data = sectionTimes[sectionTitle];
+            const watchedTime = secondsToTime(data?.watched || 0);
+            const totalTime = secondsToTime(data?.total || 0);
+
+            cont.children[0].innerHTML = `
+                <div class="sect-container">
+                    <div class="sect-title">${sectionTitle}</div>
+                    <div class="sect-watchtime">
+                        <div class="badge">
+                            <span class="badge-prefix">Watched</span>
+                            <span class="badge-text">${watchedTime}</span>
+                        </div>
+                        <div class="badge">
+                            <span class="badge-prefix">Total</span>
+                            <span class="badge-text">${totalTime}</span>
+                        </div>
+                    </div>
+                </div>`;
+        });
+
+        const existingSidebar = document.querySelector(".sidebar-times");
+
+        if (!existingSidebar) {
+            const sidebar = document.querySelector(".course-progress");
+            const newDiv = document.createElement("div");
+            const watchedTime = secondsToTime(sectionTimes.totalWatched || 0);
+            const totalTime = secondsToTime(sectionTimes.totalTime || 0);
+            const left = secondsToTime(sectionTimes.totalTime - sectionTimes.totalWatched);
+
+            newDiv.innerHTML = `
+                <div class="sidebar-times">
+                    <div class="badge">
+                        <span class="badge-prefix">Course Length</span>
+                        <span class="badge-text">${totalTime}</span>
+                    </div>
+                    <div class="badge">
+                        <span class="badge-prefix">Total Watched</span>
+                        <span class="badge-text">${watchedTime}</span>
+                    </div>
+                    <div class="badge">
+                        <span class="badge-prefix">Total Left</span>
+                        <span class="badge-text">${left}</span>
+                    </div>
+                </div>`;
+            sidebar.insertAdjacentElement("afterend", newDiv);
+        }
+    };
+
+    const updateFunctionality = (isEnabled) => {
+        if (!isEnabled) {
+            const elementsToRemove = [
+                ...document.querySelectorAll(".sect-watchtime"),
+                ...document.querySelectorAll(".sidebar-times"),
+            ];
+
+            elementsToRemove.forEach((element) => {
+                element.parentNode.removeChild(element);
+            });
+            return;
+        }
+
+        updateSectionTimes();
+    };
+
+    chrome.storage.onChanged.addListener((changes, namespace) => {
+        if (namespace === "sync" && "ztmSectionTimesCheckboxIsChecked" in changes) {
+            const value = changes.ztmSectionTimesCheckboxIsChecked.newValue || false;
+            updateFunctionality(value);
+        }
     });
 
-    // Update HTML for each container based on the calculated times
-    Array.from(containers).forEach((cont) => {
-        const alreadyHasTitleSect =
-            cont.children[0].querySelector(".sect-title");
-
-        const sectionTitle = alreadyHasTitleSect
-            ? alreadyHasTitleSect.innerText
-            : cont.children[0].innerText;
-
-        const data = sectionTimes[sectionTitle];
-        const watchedTime = secondsToTime(data?.watched || 0);
-        const totalTime = secondsToTime(data?.total || 0);
-
-        cont.children[0].innerHTML = `
-      <div class="sect-container">
-        <div class="sect-title">${sectionTitle}</div>
-        <div class="sect-watchtime">
-          <div class="badge">
-            <span class="badge-prefix">Watched</span>
-            <span class="badge-text">${watchedTime}</span>
-          </div>
-          <div class="badge">
-            <span class="badge-prefix">Total</span>
-            <span class="badge-text">${totalTime}</span>
-          </div>
-        </div>
-      </div>`;
-    });
-
-    const existingSidebar = document.querySelector(".sidebar-times");
-
-    if (!existingSidebar) {
-        // Update sidebar with overall course times
-        const sidebar = document.querySelector(".course-progress");
-        const newDiv = document.createElement("div");
-        const watchedTime = secondsToTime(sectionTimes.totalWatched || 0);
-        const totalTime = secondsToTime(sectionTimes.totalTime || 0);
-        const left = secondsToTime(
-            sectionTimes.totalTime - sectionTimes.totalWatched,
-        );
-
-        newDiv.innerHTML = `
-    <div class="sidebar-times">
-      <div class="badge">
-        <span class="badge-prefix">Course Length</span>
-        <span class="badge-text">${totalTime}</span>
-      </div>
-      <div class="badge">
-        <span class="badge-prefix">Total Watched</span>
-        <span class="badge-text">${watchedTime}</span>
-      </div>
-      <div class="badge">
-        <span class="badge-prefix">Total Left</span>
-        <span class="badge-text">${left}</span>
-      </div>
-    </div>`;
-        sidebar.insertAdjacentElement("afterend", newDiv);
-    }
-};
-
-// Function to enable/disable functionality based on Chrome storage
-const updateFunctionality = (isEnabled) => {
-    if (!isEnabled) {
-        // Remove existing elements related to functionality
-        const elementsToRemove = [
-            ...document.querySelectorAll(".sect-watchtime"),
-            ...document.querySelectorAll(".sidebar-times"),
-        ];
-
-        elementsToRemove.forEach((element) => {
-            element.parentNode.removeChild(element);
-        });
-        return;
-    }
-
-    // Call the function to update section times and badges
-    updateSectionTimes();
-};
-
-// Listen for changes in Chrome storage
-chrome.storage.onChanged.addListener((changes, namespace) => {
-    if (namespace === "sync" && "ztmSectionTimesCheckboxIsChecked" in changes) {
-        const value =
-            changes.ztmSectionTimesCheckboxIsChecked.newValue || false;
-        // Update functionality based on the changed value
-        updateFunctionality(value);
-    }
-});
-
-// Use arrow function for MutationObserver
-const observer = new MutationObserver((mutations) => {
-    const existingSidebarTimes = document.querySelector(".sidebar-times");
-    const existingSectCont = document.querySelector(".sect-container");
-    const isRightPage = window.location.pathname.includes("courses/enrolled");
-
-    isRightPage &&
+    const ztmSectionTimesObserver = new MutationObserver((mutations) => {
         chrome.storage.sync.get("ztmSectionTimesCheckboxIsChecked", (data) => {
             const isEnabled = data?.ztmSectionTimesCheckboxIsChecked || false;
-            // Call the updateFunctionality with the retrieved isEnabled state
-            if (!existingSectCont && !existingSidebarTimes && isRightPage) {
-                updateFunctionality(isEnabled);
-            }
+            updateFunctionality(isEnabled);
         });
-});
+    });
 
-// Use arrow function for observer.observe
-observer.observe(document.documentElement, { childList: true, subtree: true });
+    ztmSectionTimesObserver.observe(document.documentElement, { childList: true, subtree: true });
+}

--- a/scripts/ztm-toggle-sidebar.js
+++ b/scripts/ztm-toggle-sidebar.js
@@ -14,12 +14,12 @@ createZtmToggleSidebar.innerHTML = `
     </div> 
 `;
 
-const homeBackIcon = document.querySelector('.nav-icon-back');
+const toggleSidebarHomeBackIcon = document.querySelector('.nav-icon-back');
 
-// Check the `homeBackIcon` to prevent conflix
-if (homeBackIcon) {
+// Check the `toggleSidebarHomeBackIcon` to prevent conflix
+if (toggleSidebarHomeBackIcon) {
     // Add ZTM Toggle
-    homeBackIcon.parentNode.insertBefore(createZtmToggleSidebar, homeBackIcon.nextSibling);
+    toggleSidebarHomeBackIcon.parentNode.insertBefore(createZtmToggleSidebar, toggleSidebarHomeBackIcon.nextSibling);
     // Get the ZTM Toggle Checkbox
     const ztmToggleCheckbox = document.getElementById('ztm-toggle-checkbox');
 


### PR DESCRIPTION
@MattCSmith @aneagoie 

* Added the `Hide Lecture Title` feature.
* Disabled the `Section Time` feature.

I found the `section-time` feature had a lot of bugs to fix. I tried to fix it, but nothing worked. I must rewrite all the codes and adapt the concept as @MattCSmith did. So, I won't fix that feature for a while and will keep working on the `fav-course` feature. 

I want to point out some bugs I found when I tried to fix the `section-time` feature:

**Problem 1**
The biggest problem is the `observer`. The section time observer is kept running when the user is on the course info page. I tried to keep the bug, but I found no way. So, That observer problem got right into my mind. 
I used observers for the `toggle-sidebar` and `hide-lecture-title` functions. What if my observers are kept running, too? So, I added `console.log('Observer is running...')` to catch. I opened my console log and tried to on/off the `hide-lecture-title` and `toggle-sidebar` features. My observer functions in both features are only run once when I toggle the features. I kept testing why the `section-time` observer was running all the time. But no luck. It even crashed my Chrome twice. I had to force quit :( 

**Problem 2**
The section time doesn't keep showing when I go to the home page and go back to the course info page. I also tried to track with the observer, but it doesn't work.

**Problem 3**
The section time elements keep showing on the home page. I haven't tested that problem. I think there is a problem with adding `innerHTML`. The section time elements might be added even when the page is changed. 
I also found they kept showing on the lecture learning page. But I fixed that error by tracking with the `backlink icon`. It solved it. But I haven't solved why the section time elements showing on the home page.